### PR TITLE
Add dynamic trip creation form

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,9 +1,14 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { supabase } from '@/utils/supabase/client';
-import LogoutButton from '@/components/LogoutButton';
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
+import { supabase } from "@/utils/supabase/client";
+import LogoutButton from "@/components/LogoutButton";
+
+const AddTripForm = dynamic(() => import("@/components/AddTripForm"), {
+  ssr: false,
+});
 
 type Trip = {
   id: string;
@@ -17,6 +22,7 @@ export default function DashboardPage() {
   const [userId, setUserId] = useState<string | null>(null);
   const [trips, setTrips] = useState<Trip[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
 
   useEffect(() => {
     const fetchTrips = async () => {
@@ -26,20 +32,20 @@ export default function DashboardPage() {
       } = await supabase.auth.getSession();
 
       if (sessionError || !session?.user) {
-        router.push('/login');
+        router.push("/login");
         return;
       }
 
       setUserId(session.user.id);
 
       const { data, error } = await supabase
-        .from('Trip')
-        .select('*')
-        .eq('user_id', session.user.id)
-        .order('start_date', { ascending: true });
+        .from("Trip")
+        .select("*")
+        .eq("user_id", session.user.id)
+        .order("start_date", { ascending: true });
 
       if (error) {
-        console.error('Failed to fetch trips:', error.message);
+        console.error("Failed to fetch trips:", error.message);
       } else {
         setTrips(data);
       }
@@ -53,17 +59,28 @@ export default function DashboardPage() {
   if (loading) return <p>読み込み中...</p>;
 
   return (
-    <div style={{ padding: '2rem' }}>
+    <div style={{ padding: "2rem" }}>
       <h1>マイ旅行一覧</h1>
       <LogoutButton />
+      <div style={{ margin: "1rem 0" }}>
+        <button onClick={() => setShowForm(true)}>新しい旅行を追加</button>
+      </div>
+      {showForm && userId && (
+        <AddTripForm
+          userId={userId}
+          onCreated={(trip) => setTrips([...trips, trip])}
+          onCancel={() => setShowForm(false)}
+        />
+      )}
 
       {trips.length === 0 ? (
         <p>旅行が見つかりません。新しい旅行を作成してください。</p>
       ) : (
         <ul>
           {trips.map((trip) => (
-            <li key={trip.id} style={{ marginBottom: '1rem' }}>
-              <strong>{trip.title}</strong><br />
+            <li key={trip.id} style={{ marginBottom: "1rem" }}>
+              <strong>{trip.title}</strong>
+              <br />
               {trip.start_date} 〜 {trip.end_date}
             </li>
           ))}

--- a/src/components/AddTripForm.tsx
+++ b/src/components/AddTripForm.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { supabase } from "@/utils/supabase/client";
+import type { Trip } from "@/types/trip";
+
+type Props = {
+  userId: string;
+  onCreated: (trip: Trip) => void;
+  onCancel: () => void;
+};
+
+export default function AddTripForm({ userId, onCreated, onCancel }: Props) {
+  const [title, setTitle] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const { data, error } = await supabase
+      .from("Trip")
+      .insert({
+        user_id: userId,
+        title,
+        start_date: startDate || null,
+        end_date: endDate || null,
+      })
+      .select()
+      .single();
+    setLoading(false);
+    if (error) {
+      console.error("Failed to create trip:", error.message);
+      return;
+    }
+    if (data) {
+      onCreated(data as Trip);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ marginTop: "1rem" }}>
+      <div>
+        <label>
+          タイトル:
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          開始日:
+          <input
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          終了日:
+          <input
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+          />
+        </label>
+      </div>
+      <div style={{ marginTop: "0.5rem" }}>
+        <button type="submit" disabled={loading}>
+          {loading ? "保存中..." : "保存"}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          style={{ marginLeft: "0.5rem" }}
+        >
+          キャンセル
+        </button>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- allow dashboard to open a form for creating a new trip
- create `AddTripForm` component

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch font files)*

------
https://chatgpt.com/codex/tasks/task_e_688d46b9df00832faf5a933e69f07d72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a button to the dashboard for adding a new trip.
  * Introduced a form that allows users to create and submit new trips, including title and optional start/end dates.
  * Users can cancel the form or submit it to add a trip, with immediate updates to the trip list.

* **Style**
  * Minor improvements to button labels and form layout, including Japanese text for enhanced localization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->