### PR TITLE
refactor: unify Trip type usage

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,17 +5,11 @@ import { useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import { supabase } from "@/utils/supabase/client";
 import LogoutButton from "@/components/LogoutButton";
+import type { Trip } from "@/types";
 
 const AddTripForm = dynamic(() => import("@/components/AddTripForm"), {
   ssr: false,
 });
-
-type Trip = {
-  id: string;
-  title: string;
-  start_date: string | null;
-  end_date: string | null;
-};
 
 export default function DashboardPage() {
   const router = useRouter();
@@ -47,7 +41,7 @@ export default function DashboardPage() {
       if (error) {
         console.error("Failed to fetch trips:", error.message);
       } else {
-        setTrips(data);
+        setTrips(data as Trip[]);
       }
 
       setLoading(false);

--- a/src/components/AddTripForm.tsx
+++ b/src/components/AddTripForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { supabase } from "@/utils/supabase/client";
-import type { Trip } from "@/types/trip";
+import type { Trip } from "@/types";
 
 type Props = {
   userId: string;

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -1,15 +1,15 @@
 // src/types/trip.ts
 
 export type Trip = {
-    id:       string;
-    user_id:  string;
-    title:    string;
-    purpose?: string | null;
-    start_date: string; // ISO 8601 format
-    end_date:   string; // ISO 8601 format
+    id:         string;
+    user_id:    string;
+    title:      string;
+    purpose?:   string | null;
+    start_date: string | null; // ISO 8601 format
+    end_date:   string | null; // ISO 8601 format
     currencyId?: string | null;
     timezoneId?: string | null;
-    cratedAt:    string;
-    updatedAt:   string;
+    createdAt:  string;
+    updatedAt:  string;
 };
 


### PR DESCRIPTION
## Summary
- fix typo in `Trip` type and allow nullable dates
- remove duplicate `Trip` type definition in dashboard
- update form component to use centralized `Trip` type

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_688da58e7274832fb077a6d40abd838a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the trip data, renaming `cratedAt` to `createdAt`.

* **Refactor**
  * Updated trip date fields to support both string and null values.
  * Improved type consistency across the application by standardizing imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->