### PR TITLE
refactor: standardize database naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ src/
 └── types/            # 型定義
 ```
 
+## 📚 Database Naming
+
+See [docs/database-naming.md](docs/database-naming.md) for table and field naming conventions.
+
 ## 📄 今後のロードマップ（Roadmap）
 
 -

--- a/docs/database-naming.md
+++ b/docs/database-naming.md
@@ -1,0 +1,23 @@
+# Database Naming Conventions
+
+This project standardizes database naming to follow common practices in the Next.js community.
+
+## Tables
+- **Format:** `snake_case` plural (e.g., `trips`, `checklist_items`)
+- **Master tables:** prefix with `mst_` (e.g., `mst_currencies`)
+
+## Prisma Models
+- **Format:** `PascalCase` (e.g., `Trip`, `ChecklistItem`)
+- **Master models:** prefix with `Mst` (e.g., `MstCurrency`)
+
+## Columns
+- **Format:** `snake_case` (e.g., `user_id`, `start_date`)
+- Prisma fields use `camelCase` with `@map` to match column names (e.g., `userId @map("user_id")`).
+
+## Common Fields
+Every table includes:
+- `id` – `String @id @default(uuid())`
+- `created_at` – tracked via Prisma field `createdAt @default(now())`
+- `updated_at` – tracked via Prisma field `updatedAt @updatedAt`
+
+These conventions ensure consistent naming across the schema and codebase.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,110 +11,150 @@ datasource db {
 }
 
 // --- Master Tables ---
-model M_Currency {
-  id       String    @id @default(uuid())
-  code     String    @unique
-  name     String
-  symbol   String?
-  trips    Trip[]
-  profiles Profile[]
+model MstCurrency {
+  id        String     @id @default(uuid())
+  code      String     @unique
+  name      String
+  symbol    String?
+  trips     Trip[]
+  profiles  Profile[]
+  createdAt DateTime   @default(now()) @map("created_at")
+  updatedAt DateTime   @updatedAt @default(now()) @map("updated_at")
+
+  @@map("mst_currencies")
 }
 
-model M_Timezone {
-  id       String    @id @default(uuid())
-  name     String    @unique
-  offset   String?
-  trips    Trip[]
-  profiles Profile[]
+model MstTimezone {
+  id        String     @id @default(uuid())
+  name      String     @unique
+  offset    String?
+  trips     Trip[]
+  profiles  Profile[]
+  createdAt DateTime   @default(now()) @map("created_at")
+  updatedAt DateTime   @updatedAt @default(now()) @map("updated_at")
+
+  @@map("mst_timezones")
 }
 
-model M_CheckItem {
+model MstCheckItem {
   id             String          @id @default(uuid())
   label          String
   category       String?
   checklistItems ChecklistItem[]
+  createdAt      DateTime        @default(now()) @map("created_at")
+  updatedAt      DateTime        @updatedAt @default(now()) @map("updated_at")
+
+  @@map("mst_check_items")
 }
 
-model M_Activity {
+model MstActivity {
   id          String      @id @default(uuid())
   name        String      @unique
   category    String?
   itineraries Itinerary[]
+  createdAt   DateTime    @default(now()) @map("created_at")
+  updatedAt   DateTime    @updatedAt @default(now()) @map("updated_at")
+
+  @@map("mst_activities")
 }
 
-model M_Locale {
-  id       String    @id @default(uuid())
-  code     String    @unique
-  label    String
-  profiles Profile[]
+model MstLocale {
+  id        String     @id @default(uuid())
+  code      String     @unique
+  label     String
+  profiles  Profile[]
+  createdAt DateTime   @default(now()) @map("created_at")
+  updatedAt DateTime   @updatedAt @default(now()) @map("updated_at")
+
+  @@map("mst_locales")
 }
 
 // --- User Related ---
 model Profile {
-  id         String      @id @default(uuid())
-  user_id    String      @unique
+  id         String       @id @default(uuid())
+  userId     String       @unique @map("user_id")
   nickname   String?
-  locale     M_Locale?   @relation(fields: [localeId], references: [id])
-  localeId   String?
-  currency   M_Currency? @relation(fields: [currencyId], references: [id])
-  currencyId String?
-  timezone   M_Timezone? @relation(fields: [timezoneId], references: [id])
-  timezoneId String?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt @default(now())
+  locale     MstLocale?   @relation(fields: [localeId], references: [id])
+  localeId   String?      @map("locale_id")
+  currency   MstCurrency? @relation(fields: [currencyId], references: [id])
+  currencyId String?      @map("currency_id")
+  timezone   MstTimezone? @relation(fields: [timezoneId], references: [id])
+  timezoneId String?      @map("timezone_id")
+  createdAt  DateTime     @default(now()) @map("created_at")
+  updatedAt  DateTime     @updatedAt @default(now()) @map("updated_at")
+
+  @@map("profiles")
 }
 
 model Trip {
-  id         String      @id @default(uuid())
-  user_id    String
+  id         String       @id @default(uuid())
+  userId     String       @map("user_id")
   title      String
   purpose    String?
-  start_date DateTime
-  end_date   DateTime
-  currency   M_Currency? @relation(fields: [currencyId], references: [id])
-  currencyId String?
-  timezone   M_Timezone? @relation(fields: [timezoneId], references: [id])
-  timezoneId String?
+  startDate  DateTime     @map("start_date")
+  endDate    DateTime     @map("end_date")
+  currency   MstCurrency? @relation(fields: [currencyId], references: [id])
+  currencyId String?      @map("currency_id")
+  timezone   MstTimezone? @relation(fields: [timezoneId], references: [id])
+  timezoneId String?      @map("timezone_id")
   days       Day[]
   checklist  Checklist[]
-  createdAt  DateTime    @default(now())
-  updatedAt DateTime @updatedAt @default(now())
+  createdAt  DateTime     @default(now()) @map("created_at")
+  updatedAt  DateTime     @updatedAt @default(now()) @map("updated_at")
+
+  @@map("trips")
 }
 
 model Day {
-  id          String      @id @default(uuid())
-  trip        Trip        @relation(fields: [tripId], references: [id])
-  tripId      String
-  date        DateTime
-  note        String?
+  id         String      @id @default(uuid())
+  trip       Trip        @relation(fields: [tripId], references: [id])
+  tripId     String      @map("trip_id")
+  date       DateTime
+  note       String?
   itineraries Itinerary[]
+  createdAt  DateTime    @default(now()) @map("created_at")
+  updatedAt  DateTime    @updatedAt @default(now()) @map("updated_at")
+
+  @@map("days")
 }
 
 model Itinerary {
   id         String      @id @default(uuid())
   day        Day         @relation(fields: [dayId], references: [id])
-  dayId      String
-  start_time DateTime
-  end_time   DateTime?
+  dayId      String      @map("day_id")
+  startTime  DateTime    @map("start_time")
+  endTime    DateTime?   @map("end_time")
   location   String?
   memo       String?
-  activity   M_Activity? @relation(fields: [activityId], references: [id])
-  activityId String?
+  activity   MstActivity? @relation(fields: [activityId], references: [id])
+  activityId String?     @map("activity_id")
+  createdAt  DateTime    @default(now()) @map("created_at")
+  updatedAt  DateTime    @updatedAt @default(now()) @map("updated_at")
+
+  @@map("itineraries")
 }
 
 model Checklist {
-  id     String          @id @default(uuid())
-  trip   Trip            @relation(fields: [tripId], references: [id])
-  tripId String
-  title  String
-  items  ChecklistItem[]
+  id         String          @id @default(uuid())
+  trip       Trip            @relation(fields: [tripId], references: [id])
+  tripId     String          @map("trip_id")
+  title      String
+  items      ChecklistItem[]
+  createdAt  DateTime        @default(now()) @map("created_at")
+  updatedAt  DateTime        @updatedAt @default(now()) @map("updated_at")
+
+  @@map("checklists")
 }
 
 model ChecklistItem {
-  id          String      @id @default(uuid())
-  checklist   Checklist   @relation(fields: [checklistId], references: [id])
-  checklistId String
-  checkitem   M_CheckItem @relation(fields: [checkitemId], references: [id])
-  checkitemId String
-  isChecked   Boolean     @default(false)
+  id          String       @id @default(uuid())
+  checklist   Checklist    @relation(fields: [checklistId], references: [id])
+  checklistId String       @map("checklist_id")
+  checkitem   MstCheckItem @relation(fields: [checkitemId], references: [id])
+  checkitemId String       @map("checkitem_id")
+  isChecked   Boolean      @default(false) @map("is_checked")
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @default(now()) @map("updated_at")
+
+  @@map("checklist_items")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,7 +4,7 @@ const prisma = new PrismaClient();
 
 async function main() {
   // --- Timezones ---
-  await prisma.m_Timezone.createMany({
+  await prisma.mstTimezone.createMany({
     data: [
       { name: 'JST', offset: '+09:00' },
       { name: 'HST', offset: '-10:00' },
@@ -15,7 +15,7 @@ async function main() {
   });
 
   // --- Locales ---
-  await prisma.m_Locale.createMany({
+  await prisma.mstLocale.createMany({
     data: [
       { code: 'ja-JP', label: '日本語' },
       { code: 'en-US', label: 'English' },
@@ -24,7 +24,7 @@ async function main() {
   });
 
   // --- Currencies ---
-  await prisma.m_Currency.createMany({
+  await prisma.mstCurrency.createMany({
     data: [
       { code: 'JPY', name: 'Japanese Yen', symbol: '¥' },
       { code: 'USD', name: 'US Dollar', symbol: '$' },

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -2,6 +2,9 @@
 import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
+/**
+ * Seeds the database with initial timezone, locale, and currency data if not already present.
+ */
 async function main() {
   // --- Timezones ---
   await prisma.mstTimezone.createMany({

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -33,7 +33,7 @@ export default function DashboardPage() {
       setUserId(session.user.id);
 
       const { data, error } = await supabase
-        .from("Trip")
+        .from("trips")
         .select("*")
         .eq("user_id", session.user.id)
         .order("start_date", { ascending: true });
@@ -41,7 +41,19 @@ export default function DashboardPage() {
       if (error) {
         console.error("Failed to fetch trips:", error.message);
       } else {
-        setTrips(data as Trip[]);
+        const mapped: Trip[] = (data || []).map((t) => ({
+          id: t.id,
+          userId: t.user_id,
+          title: t.title,
+          purpose: t.purpose,
+          startDate: t.start_date,
+          endDate: t.end_date,
+          currencyId: t.currency_id,
+          timezoneId: t.timezone_id,
+          createdAt: t.created_at,
+          updatedAt: t.updated_at,
+        }));
+        setTrips(mapped);
       }
 
       setLoading(false);
@@ -75,7 +87,7 @@ export default function DashboardPage() {
             <li key={trip.id} style={{ marginBottom: "1rem" }}>
               <strong>{trip.title}</strong>
               <br />
-              {trip.start_date} 〜 {trip.end_date}
+              {trip.startDate} 〜 {trip.endDate}
             </li>
           ))}
         </ul>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,6 +11,11 @@ const AddTripForm = dynamic(() => import("@/components/AddTripForm"), {
   ssr: false,
 });
 
+/**
+ * Displays the authenticated user's list of trips, allowing them to add new trips and log out.
+ *
+ * Redirects unauthenticated users to the login page. Fetches and displays trips associated with the current user, and provides a form for creating new trips. Shows loading and empty states as appropriate.
+ */
 export default function DashboardPage() {
   const router = useRouter();
   const [userId, setUserId] = useState<string | null>(null);

--- a/src/components/AddTripForm.tsx
+++ b/src/components/AddTripForm.tsx
@@ -10,6 +10,17 @@ type Props = {
   onCancel: () => void;
 };
 
+/**
+ * Renders a form for creating a new trip associated with a user.
+ *
+ * Allows users to input a trip title, start date, and end date, then submit the form to create a new trip entry. On successful creation, invokes the provided callback with the created Trip object. Also provides a cancel option to abort the creation process.
+ *
+ * @param userId - The identifier of the user creating the trip
+ * @param onCreated - Callback invoked with the created Trip object upon successful creation
+ * @param onCancel - Callback invoked when the user cancels the form
+ *
+ * @returns A React element representing the trip creation form
+ */
 export default function AddTripForm({ userId, onCreated, onCancel }: Props) {
   const [title, setTitle] = useState("");
   const [startDate, setStartDate] = useState("");

--- a/src/components/AddTripForm.tsx
+++ b/src/components/AddTripForm.tsx
@@ -20,7 +20,7 @@ export default function AddTripForm({ userId, onCreated, onCancel }: Props) {
     e.preventDefault();
     setLoading(true);
     const { data, error } = await supabase
-      .from("Trip")
+      .from("trips")
       .insert({
         user_id: userId,
         title,
@@ -35,7 +35,19 @@ export default function AddTripForm({ userId, onCreated, onCancel }: Props) {
       return;
     }
     if (data) {
-      onCreated(data as Trip);
+      const trip: Trip = {
+        id: data.id,
+        userId: data.user_id,
+        title: data.title,
+        purpose: data.purpose,
+        startDate: data.start_date,
+        endDate: data.end_date,
+        currencyId: data.currency_id,
+        timezoneId: data.timezone_id,
+        createdAt: data.created_at,
+        updatedAt: data.updated_at,
+      };
+      onCreated(trip);
     }
   };
 

--- a/src/types/checklist.ts
+++ b/src/types/checklist.ts
@@ -4,6 +4,8 @@ export type Checklist = {
     id:     string;
     tripId: string;
     title:  string;
+    createdAt: string;
+    updatedAt: string;
 };
 
 export type ChecklistItem = {
@@ -11,5 +13,7 @@ export type ChecklistItem = {
     checklistId: string;
     checkitemId: string;
     isChecked:   boolean;
+    createdAt:   string;
+    updatedAt:   string;
 };
 

--- a/src/types/day.ts
+++ b/src/types/day.ts
@@ -5,5 +5,7 @@ export type Day = {
     tripId:  string;
     date:    string; // ISO 8601 format
     note?:   string | null;
+    createdAt: string;
+    updatedAt: string;
 };
 

--- a/src/types/itinerary.ts
+++ b/src/types/itinerary.ts
@@ -3,10 +3,12 @@
 export type Itinerary = {
     id: string;
     dayId: string;
-    start_time: string; // ISO 8601 format
-    end_time?:  string | null; // ISO 8601 format
+    startTime: string; // ISO 8601 format
+    endTime?:  string | null; // ISO 8601 format
     location?:  string | null;
     memo?:      string | null;
     activityId?:string | null; // Optional, if the itinerary is linked to an activity
+    createdAt: string;
+    updatedAt: string;
 };
 

--- a/src/types/master.ts
+++ b/src/types/master.ts
@@ -1,40 +1,49 @@
 // src/types/master.ts
 
 // --- Currency
-export type M_Currency = {
-    id:          string;
-    name:        string;
-    code:        string;
-    symbol?:     string | null;
+export type MstCurrency = {
+    id:        string;
+    name:      string;
+    code:      string;
+    symbol?:   string | null;
+    createdAt: string;
+    updatedAt: string;
 };
 
 
 // --- Timezone
-export type M_Timezone = {
-    id:          string;
-    name:        string;
-    offset?:     string | null; // e.g., "+09:00"
-//    isDst?:      boolean; // Daylight Saving Time
+export type MstTimezone = {
+    id:        string;
+    name:      string;
+    offset?:   string | null; // e.g., "+09:00"
+    createdAt: string;
+    updatedAt: string;
 };
 
 // --- Checklist Item
-export type M_CheckItem = {
-    id:          string;
-    label:       string;
-    category?:   string | null; // e.g., "Accommodation", "Transport"
+export type MstCheckItem = {
+    id:        string;
+    label:     string;
+    category?: string | null; // e.g., "Accommodation", "Transport"
+    createdAt: string;
+    updatedAt: string;
 };
 
 // --- Activity
-export type M_Activity = {
-    id:          string;
-    name:        string;
-    category?:   string | null; // e.g., "Sightseeing", "Dining"
+export type MstActivity = {
+    id:        string;
+    name:      string;
+    category?: string | null; // e.g., "Sightseeing", "Dining"
+    createdAt: string;
+    updatedAt: string;
 };
 
 // --- Locale
-export type M_Locale = {
-    id:          string;
-    code:        string;
-    label:       string; // e.g., "en", "ja"
+export type MstLocale = {
+    id:        string;
+    code:      string;
+    label:     string; // e.g., "en", "ja"
+    createdAt: string;
+    updatedAt: string;
 };
 

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,13 +1,12 @@
 // src/types/profile.ts
 
 export type Profile = {
-
     id:          string;
-    user_id:     string;
+    userId:      string;
     nickname?:   string | null;
     localeId?:   string | null;
     currencyId?: string | null;
     timezoneId?: string | null;
-    createdAt: string;
-    updatedAt: string;
+    createdAt:   string;
+    updatedAt:   string;
 };

--- a/src/types/trip.ts
+++ b/src/types/trip.ts
@@ -2,11 +2,11 @@
 
 export type Trip = {
     id:         string;
-    user_id:    string;
+    userId:     string;
     title:      string;
     purpose?:   string | null;
-    start_date: string | null; // ISO 8601 format
-    end_date:   string | null; // ISO 8601 format
+    startDate:  string | null; // ISO 8601 format
+    endDate:    string | null; // ISO 8601 format
     currencyId?: string | null;
     timezoneId?: string | null;
     createdAt:  string;


### PR DESCRIPTION
## Summary
- enforce snake_case table and column names while keeping Prisma models in PascalCase with camelCase fields
- document unified database naming conventions
- align Supabase queries and types with new schema

## Testing
- `npx prisma migrate status` *(fails: Environment variable not found: DIRECT_URL)*
- `npx prisma db pull` *(fails: Environment variable not found: DIRECT_URL)*
- `npx prisma generate`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688e9f630774832faf85f083f9fcc1ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new section and external document detailing standardized database naming conventions.
* **Refactor**
  * Standardized naming conventions across database tables, fields, and types, adopting camelCase for application code and snake_case for database columns.
  * Renamed master data types and models with a new prefix for clarity.
* **New Features**
  * Added creation and update timestamp fields to all major data types and models.
* **Bug Fixes**
  * Improved consistency in data mapping between database and frontend by aligning field names and formats.
* **Style**
  * Updated type definitions to use camelCase and added timestamp fields for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->